### PR TITLE
Bump org.apache.commons:commons-text from 1.9 to 1.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
-      <version>1.9</version>
+      <version>1.12.0</version>
     </dependency>
     <dependency>
       <groupId>mysql</groupId>


### PR DESCRIPTION
Bumps org.apache.commons:commons-text from 1.9 to 1.12.0.
