### PR TITLE
Bump org.apache.logging.log4j:log4j-core from 2.3 to 2.24.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.3</version>
+      <version>2.24.1</version>
       <optional>true</optional>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Bumps org.apache.logging.log4j:log4j-core from 2.3 to 2.24.1.
