### PR TITLE
Bump org.jboss.arquillian.config:arquillian-config-spi from 1.7.0.Alpha12 to 1.9.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
      <dependency>
       <groupId>org.jboss.arquillian.config</groupId>
       <artifactId>arquillian-config-spi</artifactId>
-      <version>1.7.0.Alpha12</version>
+      <version>1.9.1.Final</version>
      </dependency>
       <dependency>
       <groupId>org.jboss.arquillian.container</groupId>


### PR DESCRIPTION
Bumps org.jboss.arquillian.config:arquillian-config-spi from 1.7.0.Alpha12 to 1.9.1.Final.
