### PR TITLE
Bump org.jboss.arquillian.container:arquillian-container-impl-base from 1.7.0.Alpha12 to 1.9.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
       <dependency>
       <groupId>org.jboss.arquillian.container</groupId>
       <artifactId>arquillian-container-impl-base</artifactId>
-      <version>1.7.0.Alpha12</version>
+      <version>1.9.1.Final</version>
      </dependency>
       <dependency>
       <groupId>org.jboss.shrinkwrap.descriptors</groupId>


### PR DESCRIPTION
Bumps org.jboss.arquillian.container:arquillian-container-impl-base from 1.7.0.Alpha12 to 1.9.1.Final.
